### PR TITLE
Fix duplicate swap IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "lpeth-subgraph",
   "license": "UNLICENSED",
   "scripts": {
+    "auth": "graph auth",
     "codegen": "graph codegen",
     "build": "graph build",
     "deploy": "graph deploy --node https://api.studio.thegraph.com/deploy/ lpeth",

--- a/src/mappings/lpeth.ts
+++ b/src/mappings/lpeth.ts
@@ -171,8 +171,8 @@ export function handleSwap(event: SwapEvent): void {
   const usdPrice = ETHUSD();
   const amountInUSD = usdPrice.times(convertToDecimal(event.params.amountIn));
   const feeInUSD = usdPrice.times(convertToDecimal(event.params.fee));
-
-  let swapId = event.params.caller.toHex().concat("-").concat(pool.numSwaps.toString());
+  let numSwaps = pool.numSwaps.plus(BigInt.fromI32(1));
+  let swapId = event.params.caller.toHex().concat("-").concat(numSwaps.toString());
   let swap = new Swap(swapId);
   swap.pool = pool.id;
   swap.amount = event.params.amountIn;
@@ -191,6 +191,7 @@ export function handleSwap(event: SwapEvent): void {
   pool.volumeUSD = pool.volumeUSD.plus(amountInUSD);
   pool.fees = pool.fees.plus(event.params.fee);
   pool.feesUSD = pool.feesUSD.plus(feeInUSD);
+  pool.numSwaps = numSwaps;
   pool.save();
 
   let dayID = calculateDayID(event.block.timestamp);


### PR DESCRIPTION
Swap IDs are created with the address and an incremented value. The value wasn't properly incremented.